### PR TITLE
Use Python 3.8 by default.

### DIFF
--- a/pernosco
+++ b/pernosco
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.8
 
 from __future__ import annotations
 from typing import Optional, List, Pattern, Callable, Tuple, Dict, TypedDict, Any, Mapping, cast, Union, NewType


### PR DESCRIPTION
Feel free to reject this PR if you don't like Python 3.8 being forced as the default.